### PR TITLE
remove /map/ from path

### DIFF
--- a/src/components/app.js
+++ b/src/components/app.js
@@ -20,7 +20,7 @@ const App = () => (
     <ApolloProvider client={client}>
       <Router basename={rootPath}>
         <Route component={Home} path="/" exact />
-        <Route path="/map/:id/:dateBegin/:dateEnd" component={MapContainer} />
+        <Route path="/:id/:dateBegin/:dateEnd" component={MapContainer} />
       </Router>
     </ApolloProvider>
   </div>

--- a/src/components/line.js
+++ b/src/components/line.js
@@ -6,7 +6,7 @@ import PropTypes from "prop-types";
 
 const Line = ({ lineId, longName, shortName, transportType, dateBegin, dateEnd }) => (
   <div>
-    <Link to={{ pathname: path.join("/map", lineId, dateBegin, dateEnd) }}>
+    <Link to={{ pathname: path.join("/", lineId, dateBegin, dateEnd) }}>
       <LineIcon
         transportType={transportType}
         shortName={shortName}


### PR DESCRIPTION
Remove `/map` from path of a route line so that it fits with the the old style before migration. (Kuljettajaohje)