### PR TITLE
fix(graphql-api): Fix env for jore GraphQL API url

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,7 @@ RUN yarn
 COPY . ${WORK}
 
 ARG BUILD_ENV=production
-COPY .env.${BUILD_ENV} ${WORK}/.env
+COPY .env.${BUILD_ENV} ${WORK}/.env.production
 
 RUN yarn build
 CMD yarn run production
-


### PR DESCRIPTION
Fix env for docker build. Previously the docker build env which determines the Jore GraphQL API was not used and both dev and staging builds used the production API.