### PR TITLE
MM-503: Use type property instead of hardcoded line filtering (#161)

### DIFF
--- a/src/components/lineList.js
+++ b/src/components/lineList.js
@@ -12,7 +12,9 @@ import styles from "./lineList.module.css";
 const transportTypeOrder = ["tram", "bus"];
 
 const removeTrainsFilter = (line) => line.lineId.substring(0, 1) !== "3";
-const removeFerryFilter = (line) => line.lineId.substring(0, 4) !== "1019";
+const removeFerryFilter = (line) => {
+  return line.routes.nodes[0].type !== "07";
+};
 
 const setTransportTypeMapper = (line) => {
   if (line.lineId.substring(0, 4) >= 1001 && line.lineId.substring(0, 4) <= 1010) {
@@ -59,6 +61,7 @@ const allLinesQuery = gql`
           totalCount
           nodes {
             mode
+            type
           }
         }
       }


### PR DESCRIPTION
* MM-503: Use type property instead of hardcoded line filtering

* Revert train filter removal