### PR TITLE
AB#25225: Remove point property from restroom query

### DIFF
--- a/src/components/mapContainer.js
+++ b/src/components/mapContainer.js
@@ -86,7 +86,6 @@ const restroomQuery = gql`
           type
           lat
           lon
-          point
           dateImported
           mode
         }


### PR DESCRIPTION
"Point" datatype was creating conflicts with our GraphQL API, and wasn't used anywhere.