### PR TITLE
AB#25225: Remove point property from restroom query (#175)

### DIFF
--- a/src/components/mapContainer.js
+++ b/src/components/mapContainer.js
@@ -86,7 +86,6 @@ const restroomQuery = gql`
           type
           lat
           lon
-          point
           dateImported
           mode
         }


### PR DESCRIPTION
Removed the `point` property from ´restroomQuery` due to it being not needed and caused issues with the new Postgres 14 postgis-extension.